### PR TITLE
Feature/sort active projects to top

### DIFF
--- a/app/js/collections/builds.js
+++ b/app/js/collections/builds.js
@@ -1,3 +1,9 @@
 var Builds = Backbone.Collection.extend({
   model: Build,
+  comparator: function(build) {
+    if (build.getStatus() == Build.STATES.testing) {
+      return 0
+    }
+    return 1
+  }
 });

--- a/app/js/collections/projects.js
+++ b/app/js/collections/projects.js
@@ -1,6 +1,12 @@
 var Projects = Backbone.Collection.extend({
   model: Project,
   apiKey: null,
+  comparator: function(project) {
+    if (project.getStatus().status == Build.STATES.testing) {
+      return 0
+    }
+    return 1
+  },
 
   initialize: function(models, options) {
     if (options) {

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -5,7 +5,7 @@
   "short_name": "__MSG_Shipscope__",
   "default_locale": "en",
   "description": "Get Codeship build notifications with Shipscope.",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "icons": {
     "48": "img/shipscope_icon_48.png",
     "128": "img/shipscope_icon_128.png"


### PR DESCRIPTION
* If a build is running it should appear at the top of the builds list.
* If a project has a build that is running, the project should appear at the top of the projects list.
