### PR TITLE
Update API usage to use new Projects API. Builds are now loaded via separate requests. [resolve #16]

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,6 +48,7 @@ module.exports = function(grunt) {
             'app/js/models/project.js',
             'app/js/collections/builds.js',
             'app/js/collections/projects.js',
+            'app/js/util/codeship_api.js',
             'app/js/util/background.js'
           ]
         }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,6 +44,7 @@ module.exports = function(grunt) {
           'app/dest/shipscope-background.min.js': [
             'app/js/util/ga.js',
             'app/js/util/build_watcher.js',
+            'app/js/util/codeship_api.js',
             'app/js/models/build.js',
             'app/js/models/project.js',
             'app/js/collections/builds.js',

--- a/app/background.html
+++ b/app/background.html
@@ -9,15 +9,6 @@
   <script src='lib/backbone-min.js'></script>
   <script src='lib/async.js'></script>
 
-  <!-- <script src='dest/shipscope&#45;background.min.js'></script> -->
-  <script src='js/util/ga.js'></script>
-  <script src='js/util/build_watcher.js'></script>
-  <script src='js/models/build.js'></script>
-  <script src='js/models/project.js'></script>
-  <script src='js/collections/builds.js'></script>
-  <script src='js/collections/projects.js'></script>
-  <script src='js/util/codeship_api.js'></script>
-  <script src='js/util/background.js'></script>
-
+  <script src='dest/shipscope-background.min.js'></script>
 </body>
 </html>

--- a/app/js/collections/projects.js
+++ b/app/js/collections/projects.js
@@ -1,6 +1,7 @@
 var Projects = Backbone.Collection.extend({
   model: Project,
   apiKey: null,
+
   comparator: function(project) {
     if (project.getStatus().status == Build.STATES.testing) {
       return 0

--- a/app/js/models/project.js
+++ b/app/js/models/project.js
@@ -15,7 +15,7 @@ var Project = Backbone.Model.extend({
       builds = new Builds(builds)
     }
 
-    if (builds && builds.length > 0) {
+    if (builds.length > 0) {
       hasRunningBuild = builds.findWhere({status: 'testing'})
       if (hasRunningBuild) {
         projectStatus = Build.STATES.testing

--- a/app/js/models/project.js
+++ b/app/js/models/project.js
@@ -11,7 +11,6 @@ var Project = Backbone.Model.extend({
 
     if (builds && builds.length > 0) {
       hasRunningBuild = builds.findWhere({status: 'testing'})
-      console.debug('build.status.hasRunning:', hasRunningBuild)
       if (hasRunningBuild) {
         projectStatus = Build.STATES.testing
       } else {

--- a/app/js/models/project.js
+++ b/app/js/models/project.js
@@ -15,7 +15,7 @@ var Project = Backbone.Model.extend({
       builds = new Builds(builds)
     }
 
-    if (builds.length > 0) {
+    if (builds && builds.length > 0) {
       hasRunningBuild = builds.findWhere({status: 'testing'})
       if (hasRunningBuild) {
         projectStatus = Build.STATES.testing

--- a/app/js/models/project.js
+++ b/app/js/models/project.js
@@ -1,26 +1,20 @@
 var Project = Backbone.Model.extend({
   tagName: 'li',
 
-  builds: function() {
-    api = new CodeshipApi()
-    builds = api.fetchProjects(this)
-    builds_collection = new Builds(builds)
-    return builds_collection
-  },
-
   getStatus: function() {
     var
+      builds = new Builds(this.attributes.builds),
       mostRecentBuilds = {},
       projectStatus = Build.STATES.success,
       hasRunningBuild,
       lastMasterBuild;
 
-    if (this.builds.length > 0) {
-      hasRunningBuild = this.builds.findWhere({status: 'testing'})
+    if (builds.length > 0) {
+      hasRunningBuild = builds.findWhere({status: 'testing'})
       if (hasRunningBuild) {
         projectStatus = Build.STATES.testing
       } else {
-        lastMasterBuild = this.builds.findWhere({branch: 'master'})
+        lastMasterBuild = builds.findWhere({branch: 'master'})
         if (lastMasterBuild) {
           projectStatus = lastMasterBuild.getStatus()
         }

--- a/app/js/models/project.js
+++ b/app/js/models/project.js
@@ -9,6 +9,12 @@ var Project = Backbone.Model.extend({
       hasRunningBuild,
       lastMasterBuild;
 
+    // we lose the backbone collection,
+    // init builds collection after passing to the frontend
+    if (Array.isArray(builds)) {
+      builds = new Builds(builds)
+    }
+
     if (builds && builds.length > 0) {
       hasRunningBuild = builds.findWhere({status: 'testing'})
       if (hasRunningBuild) {

--- a/app/js/models/project.js
+++ b/app/js/models/project.js
@@ -1,20 +1,26 @@
 var Project = Backbone.Model.extend({
   tagName: 'li',
 
+  builds: function() {
+    api = new CodeshipApi()
+    builds = api.fetchProjects(this)
+    builds_collection = new Builds(builds)
+    return builds_collection
+  },
+
   getStatus: function() {
     var
-      builds = new Builds(this.attributes.builds),
       mostRecentBuilds = {},
       projectStatus = Build.STATES.success,
       hasRunningBuild,
       lastMasterBuild;
 
-    if (builds.length > 0) {
-      hasRunningBuild = builds.findWhere({status: 'testing'})
+    if (this.builds.length > 0) {
+      hasRunningBuild = this.builds.findWhere({status: 'testing'})
       if (hasRunningBuild) {
         projectStatus = Build.STATES.testing
       } else {
-        lastMasterBuild = builds.findWhere({branch: 'master'})
+        lastMasterBuild = this.builds.findWhere({branch: 'master'})
         if (lastMasterBuild) {
           projectStatus = lastMasterBuild.getStatus()
         }
@@ -24,5 +30,5 @@ var Project = Backbone.Model.extend({
     return {
       status: projectStatus
     }
-  }
+  },
 });

--- a/app/js/models/project.js
+++ b/app/js/models/project.js
@@ -15,7 +15,7 @@ var Project = Backbone.Model.extend({
       builds = new Builds(builds)
     }
 
-    if (builds && builds.length > 0) {
+    if (typeof builds !== "undefined" && builds !== null && builds.length > 0) {
       hasRunningBuild = builds.findWhere({status: 'testing'})
       if (hasRunningBuild) {
         projectStatus = Build.STATES.testing

--- a/app/js/util/background.js
+++ b/app/js/util/background.js
@@ -2,6 +2,7 @@ var Background = function() {
   var
     POLLING_INTERVAL = 10000,
     ANALYTICS_INTERVAL = 60000,
+    api = new CodeshipApi(),
 
     buildWatcher,
     pollingInterval,
@@ -49,9 +50,10 @@ var Background = function() {
     },
 
     fetchProjectsFromCodeship = function() {
-      api = new CodeshipApi()
-      projects = api.fetchProjects()
-      buildWatcher.scan(projects)
+      api.fetchProjects(function(_projects) {
+        projects = _projects
+        buildWatcher.scan(projects)
+      })
     },
 
     getShipscopeSummary = function() {
@@ -76,12 +78,19 @@ var Background = function() {
 
     startPolling = function() {
       setInterval(fetchProjectsFromCodeship, POLLING_INTERVAL);
+    },
+
+    checkApiKey = function() {
+      chrome.storage.sync.get('api_key', function(value) {
+        if (value) fetchProjectsFromCodeship()
+      });
     }
 
   return {
     initialize: function() {
       buildWatcher = new BuildWatcher()
       initIntercom();
+      checkApiKey();
       initAnalyticsPing()
       startPolling();
     }

--- a/app/js/util/background.js
+++ b/app/js/util/background.js
@@ -54,7 +54,7 @@ var Background = function() {
         options = value
         if (options) fetchProjectsFromCodeship()
       });
-    }
+    },
 
     fetchProjectsFromCodeship = function() {
       api.fetchAll(options, function(_projects) {
@@ -86,7 +86,7 @@ var Background = function() {
 
     startPolling = function() {
       setInterval(fetchProjectsFromCodeship, POLLING_INTERVAL);
-    },
+    }
 
   return {
     initialize: function() {

--- a/app/js/util/background.js
+++ b/app/js/util/background.js
@@ -49,10 +49,10 @@ var Background = function() {
       })
     },
 
-    fetchApiKeyFromLocalStorage = function(callback) {
+    fetchApiKeyFromLocalStorage = function() {
       chrome.storage.sync.get('api_key', function(value) {
         options = value
-        callback()
+        if (options) fetchProjectsFromCodeship()
       });
     }
 
@@ -87,13 +87,6 @@ var Background = function() {
     startPolling = function() {
       setInterval(fetchProjectsFromCodeship, POLLING_INTERVAL);
     },
-
-    fetchApiKeyFromLocalStorage = function() {
-      chrome.storage.sync.get('api_key', function(value) {
-        options = value
-        if (options) fetchProjectsFromCodeship()
-      });
-    }
 
   return {
     initialize: function() {

--- a/app/js/util/background.js
+++ b/app/js/util/background.js
@@ -2,9 +2,6 @@ var Background = function() {
   var
     POLLING_INTERVAL = 10000,
     ANALYTICS_INTERVAL = 60000,
-    CODESHIP_URL = 'https://codeship.com/api/v1/projects.json',
-    FAKE_URL = 'https://localhost:6060/projects.json',
-    URL = CODESHIP_URL,
 
     buildWatcher,
     pollingInterval,
@@ -51,38 +48,10 @@ var Background = function() {
       })
     },
 
-    fetchApiKeyFromLocalStorage = function() {
-      chrome.storage.sync.get('api_key', function(value) {
-        options = value
-        if (options) fetchProjectsFromCodeship()
-      });
-    },
-
     fetchProjectsFromCodeship = function() {
-      if (options && options.api_key != undefined) {
-        console.debug('fetch!');
-        // if (FAKE) {
-        //   fetchFakeProjects()
-        //   getShipscopeSummary()
-        //   if (intercom) intercom.postMessage({type: 'api_ok'})
-        //   return
-        // }
-
-        var params = 'api_key=' + options.api_key
-
-        $.getJSON(URL, params)
-          .done( function(response) {
-            var filtered = _.filter(response.projects, function(p) { return p.repository_name != null } )
-            projects = new Projects(filtered)
-            buildWatcher.scan(response.projects)
-            getShipscopeSummary()
-            if (intercom) intercom.postMessage({type: 'api_ok'})
-          })
-          .fail(function(err) {
-            ga('send', 'event', 'background', 'fetch_projects', 'error')
-            if (intercom) intercom.postMessage({type: 'error', data: err})
-          });
-      }
+      api = new CodeshipApi()
+      projects = api.fetchProjects()
+      buildWatcher.scan(projects)
     },
 
     getShipscopeSummary = function() {
@@ -99,12 +68,6 @@ var Background = function() {
       chrome.browserAction.setBadgeBackgroundColor({color: STATUS_COLORS[status.state]})
     },
 
-    fetchFakeProjects = function() {
-      json = JSON.parse('[{"id":26225,"builds":[{"id":1795957,"uuid":"2f406670-007f-0132-cb2f-5247614ee66f","status":"success","commit_id":"03aa27da48bf5d6ee5c162351a2d7f721cc1ad28","message":"testing a codeship build","branch":"backbonify"},{"id":1601722,"uuid":"70d42460-e9fd-0131-b97c-5a04e3162754","status":"testing","commit_id":"c36460f43313a549437ec410270376bf3edd4729","message":"turned this into a quite long commit message so i could consider committing this in order to see what happens","branch":"master"},{"id":1601711,"uuid":"8424fba0-007f-0132-8277-1eba7344906a","status":"error","commit_id":"fab58ad0ba4ec78efee303ef6d3dd9824cab2c78","message":"corrected backbone and less config issues.","branch":"master"},{"id":1600121,"uuid":"8905dee0-e9d9-0131-1ab9-0ec2eab3611a","status":"success","commit_id":"84beb1684c33fdb7f7287ea634adcfbdb6a6d59b","message":"testing deployment via codeship through heroku","branch":"master"},{"id":1597401,"uuid":"db9b2340-e9b0-0131-d588-2acc9bb7d407","status":"success","commit_id":"f8acebd3f5ec31e30dfca2744d65839a37951a27","message":"remove nodemon","branch":"master"},{"id":1597263,"uuid":"cb7c9950-e9ae-0131-d588-2acc9bb7d407","status":"error","commit_id":"5e5da103215485cdda811712a996799ce5a37834","message":"added nodemon to package.json","branch":"master"},{"id":1597235,"uuid":"d11930d0-e9ae-0131-0f9a-5e10f8b94a21","status":"error","commit_id":"c09f551dfa210b30a288ef1c71d22153ae0fbeac","message":"this is probably broken.","branch":"master"}],"repository_name":"codepogo/unboggler"},' + 
-          '{"id":26226,"builds":[{"id":1597235,"uuid":"d11930d0-e9ae-0131-0f9a-5e10f8b94a21","status":"success","commit_id":"c09f551dfa210b30a288ef1c71d22153ae0fbeac","message":"this is probably broken.","branch":"master"}],"repository_name":"codepogo/shipscope"}]');
-      projects = new Projects(json);
-    },
-
     initAnalyticsPing = function() {
       setInterval(function() {
         ga('send', 'event', 'background', 'active_user', 'ping')
@@ -119,7 +82,6 @@ var Background = function() {
     initialize: function() {
       buildWatcher = new BuildWatcher()
       initIntercom();
-      fetchApiKeyFromLocalStorage();
       initAnalyticsPing()
       startPolling();
     }

--- a/app/js/util/background.js
+++ b/app/js/util/background.js
@@ -50,7 +50,7 @@ var Background = function() {
     },
 
     fetchProjectsFromCodeship = function() {
-      api.fetchProjects(function(_projects) {
+      api.fetchAll(function(_projects) {
         projects = _projects
         buildWatcher.scan(projects)
       })
@@ -82,7 +82,9 @@ var Background = function() {
 
     checkApiKey = function() {
       chrome.storage.sync.get('api_key', function(value) {
-        if (value) fetchProjectsFromCodeship()
+        if (value && value.api_key != undefined) {
+          fetchProjectsFromCodeship()
+        }
       });
     }
 

--- a/app/js/util/background.js
+++ b/app/js/util/background.js
@@ -57,7 +57,14 @@ var Background = function() {
     },
 
     fetchProjectsFromCodeship = function() {
-      api.fetchAll(options, function(_projects) {
+      api.fetchAll(options, function(_projects, error) {
+        if (error) {
+          if (intercom) intercom.postMessage(error)
+          return
+        } else {
+          if (intercom) intercom.postMessage({type: 'api_ok'})
+        }
+
         projects = _projects
         buildWatcher.scan(projects)
         getShipscopeSummary()
@@ -90,8 +97,8 @@ var Background = function() {
 
   return {
     initialize: function() {
-      buildWatcher = new BuildWatcher()
       initIntercom();
+      buildWatcher = new BuildWatcher()
       fetchApiKeyFromLocalStorage();
       initAnalyticsPing()
       startPolling();

--- a/app/js/util/build_watcher.js
+++ b/app/js/util/build_watcher.js
@@ -1,6 +1,7 @@
 var BuildWatcher = (function() {
   var
     isWatching = {},
+    api = new CodeshipApi()
 
     ellipsify = function(str, max) {
       if (str == null) return str
@@ -48,7 +49,7 @@ var BuildWatcher = (function() {
       chrome.notifications.create(build.uuid, options, onCreateNotification);
 
       isWatching[build.uuid].status = 'notifying'
-    }
+    },
 
   chrome.notifications.onClicked.addListener(onNotificationClicked)
   chrome.notifications.onClosed.addListener(onNotificationClosed)
@@ -56,12 +57,14 @@ var BuildWatcher = (function() {
   return {
     scan: function(projects) {
       projects.forEach(function(project) {
-        project.builds.forEach(function(build) {
-          if (build.status == 'testing') {
-            isWatching[build.uuid] = build
-          } else if (isWatching[build.uuid] && isWatching[build.uuid].status == 'testing') {
-            showNotification(project, build)
-          }
+        api.fetchBuilds(project, function(builds){
+          builds.forEach(function(build) {
+            if (build.status == 'testing') {
+              isWatching[build.uuid] = build
+            } else if (isWatching[build.uuid] && isWatching[build.uuid].status == 'testing') {
+              showNotification(project, build)
+            }
+          })
         })
       })
     },

--- a/app/js/util/build_watcher.js
+++ b/app/js/util/build_watcher.js
@@ -49,7 +49,7 @@ var BuildWatcher = (function() {
       chrome.notifications.create(build.uuid, options, onCreateNotification);
 
       isWatching[build.uuid].status = 'notifying'
-    },
+    }
 
   chrome.notifications.onClicked.addListener(onNotificationClicked)
   chrome.notifications.onClosed.addListener(onNotificationClosed)

--- a/app/js/util/build_watcher.js
+++ b/app/js/util/build_watcher.js
@@ -27,7 +27,7 @@ var BuildWatcher = (function() {
     onNotificationClicked = function(notificationId) {
       var build = isWatching[notificationId]
       if (build) {
-        chrome.tabs.create({url: 'https://codeship.com/projects/' + build.project_id + '/builds/' + build.id})
+        chrome.tabs.create({url: 'https://codeship.com/projects/' + build.get('project_id') + '/builds/' + build.get('id')})
         clearNotification(notificationId)
       } else console.debug('could not find build for notificationId:', notificationId)
     },
@@ -37,18 +37,18 @@ var BuildWatcher = (function() {
     },
 
     showNotification = function(project, build) {
-      var msg= '[' + ellipsify(build.branch, 20) + '] ' + build.status + '\n' + ellipsify(build.message, 30),
+      var msg= '[' + ellipsify(build.get('branch'), 20) + '] ' + build.get('status') + '\n' + ellipsify(build.get('message'), 30),
           options = {
             type: "basic",
-            title: project.repository_name,
+            title: project.get('repository_name'),
             message: msg,
             priority: 1,
-            iconUrl: "img/shipscope_icon_" + build.status + "_128.png"
+            iconUrl: "img/shipscope_icon_" + build.get('status') + "_128.png"
           }
 
-      chrome.notifications.create(build.uuid, options, onCreateNotification);
+      chrome.notifications.create(build.get('uuid'), options, onCreateNotification);
 
-      isWatching[build.uuid].status = 'notifying'
+      isWatching[build.get('uuid')].status = 'notifying'
     }
 
   chrome.notifications.onClicked.addListener(onNotificationClicked)
@@ -57,10 +57,13 @@ var BuildWatcher = (function() {
   return {
     scan: function(projects) {
       projects.forEach(function(project) {
-        project.attributes.builds.forEach(function(build) {
-          if (build.status == 'testing') {
-            isWatching[build.uuid] = build
-          } else if (isWatching[build.uuid] && isWatching[build.uuid].status == 'testing') {
+        project.get('builds').forEach(function(build) {
+          var uuid = build.get('uuid'),
+              status = build.get('status')
+
+          if (status == 'testing') {
+            isWatching[uuid] = status
+          } else if (isWatching[uuid] && isWatching[uuid].get('status') == 'testing') {
             showNotification(project, build)
           }
         })

--- a/app/js/util/build_watcher.js
+++ b/app/js/util/build_watcher.js
@@ -57,7 +57,7 @@ var BuildWatcher = (function() {
   return {
     scan: function(projects) {
       projects.forEach(function(project) {
-        api.fetchBuilds(project, function(builds){
+        api.fetchBuilds(project, function(builds) {
           builds.forEach(function(build) {
             if (build.status == 'testing') {
               isWatching[build.uuid] = build

--- a/app/js/util/build_watcher.js
+++ b/app/js/util/build_watcher.js
@@ -48,7 +48,7 @@ var BuildWatcher = (function() {
 
       chrome.notifications.create(build.get('uuid'), options, onCreateNotification);
 
-      isWatching[build.get('uuid')].status = 'notifying'
+      isWatching[build.get('uuid')].set({status: 'notifying'})
     }
 
   chrome.notifications.onClicked.addListener(onNotificationClicked)
@@ -62,7 +62,7 @@ var BuildWatcher = (function() {
               status = build.get('status')
 
           if (status == 'testing') {
-            isWatching[uuid] = status
+            isWatching[uuid] = build.clone()
           } else if (isWatching[uuid] && isWatching[uuid].get('status') == 'testing') {
             showNotification(project, build)
           }

--- a/app/js/util/codeship_api.js
+++ b/app/js/util/codeship_api.js
@@ -1,9 +1,21 @@
 var CodeshipApi = (function() {
   var
-    PROJECT_URL = "https://codeship.com/api/v2/projects.json",
-    BUILD_URL = "https://codeship.com/api/v2/projects.json",
+    API_HOST = "https://codeship.com/api",
+    PROJECT_URL = API_HOST + "/v2/projects.json",
+    BUILD_URL = API_HOST + "/v1/builds.json",
 
     options,
+
+    fetchAll = function(callback) {
+      fetchProjects(function(projects) {
+        projects.forEach(function(project) {
+          fetchBuilds(project, function(builds) {
+            project.set({builds: builds});
+            callback(projects)
+          })
+        })
+      })
+    },
 
     fetchBuilds = function(project, callback) {
       fetchApiKeyFromLocalStorage(function(){
@@ -51,6 +63,10 @@ var CodeshipApi = (function() {
 
     fetchBuilds: function(project, callback) {
       fetchBuilds(project, callback)
+    },
+    fetchAll: function(callback) {
+      fetchAll(callback)
     }
+
   }
 });

--- a/app/js/util/codeship_api.js
+++ b/app/js/util/codeship_api.js
@@ -1,0 +1,49 @@
+var CodeshipApi = (function() {
+  var
+    PROJECT_URL = "https://codeship.com/api/v2/projects.json",
+    BUILD_URL = "https://codeship.com/api/v2/projects.json",
+
+    options,
+
+    fetchBuilds = function(project) {
+      var params = 'api_key=' + options.api_key + "&project_id=" + project.id
+
+      $.getJSON(BUILD_URL, params)
+        .done( function(response) {
+          return response.builds
+        })
+        .fail(function(err) {
+          ga('send', 'event', 'background', 'fetch_builds', 'error')
+          if (intercom) intercom.postMessage({type: 'error', data: err})
+        });
+    },
+
+    fetchProjects = function() {
+      if (options && options.api_key != undefined) {
+        var params = 'api_key=' + options.api_key
+
+        $.getJSON(PROJECT_URL, params)
+          .done( function(response) {
+            return response.projects
+            if (intercom) intercom.postMessage({type: 'api_ok'})
+          })
+          .fail(function(err) {
+            ga('send', 'event', 'background', 'fetch_projects', 'error')
+            if (intercom) intercom.postMessage({type: 'error', data: err})
+          });
+      }
+    },
+
+    fetchApiKeyFromLocalStorage = function() {
+      chrome.storage.sync.get('api_key', function(value) {
+        options = value
+        if (options) fetchProjectsFromCodeship()
+      });
+    }
+
+  return {
+    initialize: function() {
+      fetchApiKeyFromLocalStorage();
+    }
+  }
+});

--- a/app/js/util/codeship_api.js
+++ b/app/js/util/codeship_api.js
@@ -10,7 +10,6 @@ var CodeshipApi = (function() {
       fetchProjects(function(projects) {
         projects.forEach(function(project) {
           fetchBuilds(project, function(builds) {
-            project.set({builds: builds});
             callback(projects)
           })
         })
@@ -24,11 +23,11 @@ var CodeshipApi = (function() {
         $.getJSON(BUILD_URL, params)
           .done( function(response) {
             builds_collection = new Builds(response.builds)
+            project.set({builds: builds});
             callback(builds_collection)
           })
           .fail(function(err) {
             ga('send', 'event', 'background', 'fetch_builds', 'error')
-            if (intercom) intercom.postMessage({type: 'error', data: err})
           });
       })
     },

--- a/app/js/util/codeship_api.js
+++ b/app/js/util/codeship_api.js
@@ -26,8 +26,8 @@ var CodeshipApi = (function() {
 
       $.getJSON(BUILD_URL, params)
         .done( function(response) {
-          builds_collection = new Builds(response.builds)
-          callback(builds_collection)
+          buildsCollection = new Builds(response.builds)
+          callback(buildsCollection)
         })
         .fail(function(err) {
           ga('send', 'event', 'background', 'fetch_builds', 'error')
@@ -40,8 +40,8 @@ var CodeshipApi = (function() {
         var params = 'api_key=' + options.api_key
         $.getJSON(PROJECT_URL, params)
           .done( function(response) {
-            projects_collection = new Projects(response.projects)
-            callback(projects_collection)
+            projectsCollection = new Projects(response.projects)
+            callback(projectsCollection)
           })
           .fail(function(err) {
             ga('send', 'event', 'background', 'fetch_projects', 'error')

--- a/app/js/util/codeship_api.js
+++ b/app/js/util/codeship_api.js
@@ -5,45 +5,52 @@ var CodeshipApi = (function() {
 
     options,
 
-    fetchBuilds = function(project) {
-      var params = 'api_key=' + options.api_key + "&project_id=" + project.id
+    fetchBuilds = function(project, callback) {
+      fetchApiKeyFromLocalStorage(function(){
+        var params = 'api_key=' + options.api_key + "&project_id=" + project.id
 
-      $.getJSON(BUILD_URL, params)
-        .done( function(response) {
-          return response.builds
-        })
-        .fail(function(err) {
-          ga('send', 'event', 'background', 'fetch_builds', 'error')
-          if (intercom) intercom.postMessage({type: 'error', data: err})
-        });
-    },
-
-    fetchProjects = function() {
-      if (options && options.api_key != undefined) {
-        var params = 'api_key=' + options.api_key
-
-        $.getJSON(PROJECT_URL, params)
+        $.getJSON(BUILD_URL, params)
           .done( function(response) {
-            return response.projects
-            if (intercom) intercom.postMessage({type: 'api_ok'})
+            builds_collection = new Builds(response.builds)
+            callback(builds_collection)
           })
           .fail(function(err) {
-            ga('send', 'event', 'background', 'fetch_projects', 'error')
+            ga('send', 'event', 'background', 'fetch_builds', 'error')
             if (intercom) intercom.postMessage({type: 'error', data: err})
           });
-      }
+      })
     },
 
-    fetchApiKeyFromLocalStorage = function() {
+    fetchProjects = function(callback) {
+      fetchApiKeyFromLocalStorage(function() {
+        if (options && options.api_key != undefined) {
+          var params = 'api_key=' + options.api_key
+          $.getJSON(PROJECT_URL, params)
+            .done( function(response) {
+              projects_collection = new Projects(response.projects)
+              callback(projects_collection)
+            })
+            .fail(function(err) {
+              ga('send', 'event', 'background', 'fetch_projects', 'error')
+            });
+        }
+      })
+    },
+
+    fetchApiKeyFromLocalStorage = function(callback) {
       chrome.storage.sync.get('api_key', function(value) {
         options = value
-        if (options) fetchProjectsFromCodeship()
+        callback()
       });
     }
 
   return {
-    initialize: function() {
-      fetchApiKeyFromLocalStorage();
+    fetchProjects: function(callback) {
+      fetchProjects(callback)
+    },
+
+    fetchBuilds: function(project, callback) {
+      fetchBuilds(project, callback)
     }
   }
 });

--- a/app/js/util/codeship_api.js
+++ b/app/js/util/codeship_api.js
@@ -5,7 +5,12 @@ var CodeshipApi = (function() {
     BUILD_URL = API_HOST + "/v1/builds.json",
 
     fetchAll = function(options, callback) {
-      fetchProjects(options, function(projects) {
+      fetchProjects(options, function(projects, error) {
+        if (error) {
+          callback(null, error)
+          return
+        }
+
         async.each(projects.models, function(project, done) {
           fetchBuilds(options, project, function(builds) {
             project.set({builds: builds});
@@ -13,7 +18,7 @@ var CodeshipApi = (function() {
           })
         }, function(error) {
           if (error) {
-            // error handling
+            callback(null, error)
           } else {
             callback(projects)
           }
@@ -31,7 +36,6 @@ var CodeshipApi = (function() {
         })
         .fail(function(err) {
           ga('send', 'event', 'background', 'fetch_builds', 'error')
-          if (intercom) intercom.postMessage({type: 'error', data: err})
         });
     },
 
@@ -45,6 +49,7 @@ var CodeshipApi = (function() {
           })
           .fail(function(err) {
             ga('send', 'event', 'background', 'fetch_projects', 'error')
+            callback(null, {type: 'error', data: err})
           });
       }
     }

--- a/app/js/views/main.js
+++ b/app/js/views/main.js
@@ -70,7 +70,7 @@ var MainLayout = Backbone.Marionette.LayoutView.extend({
     $('footer').show();
 
     if (project) {
-      var builds = project.get('builds')
+      var builds = new Builds(project.get('builds'))
       var buildsView = new BuildsView({collection: builds}, {projectId: projectId})
       this.project_list.show(buildsView)
     }

--- a/app/js/views/main.js
+++ b/app/js/views/main.js
@@ -24,16 +24,15 @@ var MainLayout = Backbone.Marionette.LayoutView.extend({
         if (this.initialized) return;
 
         this.initialized = true
+        // recreate backbone collection, they get lost in the intercom
         this.collection = new Projects(msg.data)
         this.onShowHome()
       }
 
       if (msg.type == 'options.set') {
-        console.debug('options.set:', msg.data)
         this.options = new OptionsModel(msg.data)
         App.options = msg.data
 
-        console.debug('this.options:', this.options)
         if (!this.options.get('api_key')) {
           this.onShowOptions()
         }

--- a/app/js/views/options.js
+++ b/app/js/views/options.js
@@ -38,7 +38,6 @@ var OptionsView = Backbone.Marionette.LayoutView.extend({
   },
 
   destroy: function() {
-    console.debug('options.destroy')
     this.stopListeningForApiResult()
   },
 

--- a/app/js/views/projects.js
+++ b/app/js/views/projects.js
@@ -29,7 +29,7 @@ var ProjectsView = Backbone.Marionette.CollectionView.extend({
     App.intercom.onMessage.addListener(function(msg) {
       if (msg.type == 'projects.set') {
         this.switchToSlowPoller(msg.data)
-        // if (this.collection) this.collection.reset(msg.data)
+        if (this.collection) this.collection.reset(msg.data)
       }
     }.bind(this))
   },

--- a/app/popup.html
+++ b/app/popup.html
@@ -84,22 +84,7 @@
     <script src='lib/backbone.marionette.min.js'></script>
     <script src='lib/bootstrap.min.js'></script>
 
-    <!-- <script src='dest/shipscope.min.js'></script> -->
-    <script src='js/util/ga.js'></script>
-    <script src='js/models/build.js'></script>
-    <script src='js/models/project.js'></script>
-    <script src='js/models/options.js'></script>
-    <script src='js/collections/builds.js'></script>
-    <script src='js/collections/projects.js'></script>
-    <script src='js/views/build.js'></script>
-    <script src='js/views/builds.js'></script>
-    <script src='js/views/main.js'></script>
-    <script src='js/views/options.js'></script>
-    <script src='js/views/project.js'></script>
-    <script src='js/views/projects.js'></script>
-
-    <script src='js/util/codeship_api.js'></script>
-    <script src='js/app.js'></script>
+    <script src='dest/shipscope.min.js'></script>
   </body>
 </html>
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,6 +36,7 @@ module.exports = function(config) {
       'app/js/collections/builds.js',
       'app/js/collections/projects.js',
 
+      'app/js/util/codeship_api.js',
       'app/js/util/build_watcher.js',
       'app/js/views/*.js',
 

--- a/package.json
+++ b/package.json
@@ -14,20 +14,20 @@
   "author": "David McGaffin",
   "license": "ISC",
   "devDependencies": {
-    "chai": "^1.9.1",
+    "chai": "^2.1.2",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-compress": "^0.11.0",
-    "grunt-contrib-uglify": "^0.5.1",
-    "grunt-karma": "^0.8.3",
-    "karma": "^0.12.22",
+    "grunt-contrib-compress": "^0.13.0",
+    "grunt-contrib-uglify": "^0.8.0",
+    "grunt-karma": "^0.10.1",
+    "karma": "^0.12.31",
     "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^0.1.4",
-    "karma-coverage": "^0.2.6",
-    "karma-mocha": "^0.1.8",
+    "karma-chrome-launcher": "^0.1.7",
+    "karma-coverage": "^0.2.7",
+    "karma-mocha": "^0.1.10",
     "karma-phantomjs-launcher": "^0.1.4",
-    "karma-sinon-chai": "^0.2.0",
-    "mocha": "^1.21.4"
+    "karma-sinon-chai": "^0.3.0",
+    "mocha": "^2.2.1"
   }
 }

--- a/test/fixtures/builds.js
+++ b/test/fixtures/builds.js
@@ -52,7 +52,7 @@ var BuildFixtures = {
       "status": "error",
       "commit_id": "03aa27da48bf5d6ee5c162351a2d7f721cc1ad28",
       "message": "testing a codeship build",
-      "branch": "backbonify"
+      "branch": "master"
     }
   ]
 }

--- a/test/fixtures/builds.js
+++ b/test/fixtures/builds.js
@@ -1,0 +1,58 @@
+var BuildFixtures = {
+  good: [
+    {
+      "id": 1000001,
+      "uuid": "2f406670-007f-0132-cb2f-5247614ee66f",
+      "status": "success",
+      "commit_id": "03aa27da48bf5d6ee5c162351a2d7f721cc1ad28",
+      "message": "testing a codeship build",
+      "branch": "backbonify"
+    },
+    {
+      "id": 1000002,
+      "uuid": "70d42460-e9fd-0131-b97c-5a04e3162754",
+      "status": "success",
+      "commit_id": "c36460f43313a549437ec410270376bf3edd4729",
+      "message": "turned this into a quite long commit message so i could consider committing this in order to see what happens",
+      "branch": "master"
+    },
+    {
+      "id": 1000003,
+      "uuid": "8424fba0-007f-0132-8277-1eba7344906a",
+      "status": "error",
+      "commit_id": "fab58ad0ba4ec78efee303ef6d3dd9824cab2c78",
+      "message": "corrected backbone and less config issues.",
+      "branch": "master"
+    },
+    {
+      "id": 1000004,
+      "uuid": "8905dee0-e9d9-0131-1ab9-0ec2eab3611a",
+      "status": "success",
+      "commit_id": "84beb1684c33fdb7f7287ea634adcfbdb6a6d59b",
+      "message": "testing deployment via codeship through heroku",
+      "branch": "master"
+    }
+  ],
+
+  testing: [
+    {
+      "id": 1000005,
+      "uuid": "2f406670-007f-0132-cb2f-5247614ee66f",
+      "status": "testing",
+      "commit_id": "03aa27da48bf5d6ee5c162351a2d7f721cc1ad28",
+      "message": "testing a codeship build",
+      "branch": "backbonify"
+    }
+  ],
+
+  error: [
+    {
+      "id": 1000005,
+      "uuid": "2f406670-007f-0132-cb2f-5247614ee66f",
+      "status": "error",
+      "commit_id": "03aa27da48bf5d6ee5c162351a2d7f721cc1ad28",
+      "message": "testing a codeship build",
+      "branch": "backbonify"
+    }
+  ]
+}

--- a/test/fixtures/project.js
+++ b/test/fixtures/project.js
@@ -1,101 +1,11 @@
 var ProjectFixtures = {
   good: {
     "id": 9999,
-    "builds": [
-      {
-        "id": 1000001,
-        "uuid": "2f406670-007f-0132-cb2f-5247614ee66f",
-        "status": "success",
-        "commit_id": "03aa27da48bf5d6ee5c162351a2d7f721cc1ad28",
-        "message": "testing a codeship build",
-        "branch": "backbonify"
-      }, {
-        "id": 1000002,
-        "uuid": "70d42460-e9fd-0131-b97c-5a04e3162754",
-        "status": "success",
-        "commit_id": "c36460f43313a549437ec410270376bf3edd4729",
-        "message": "turned this into a quite long commit message so i could consider committing this in order to see what happens",
-        "branch": "master"
-      }, {
-        "id": 1000003,
-        "uuid": "8424fba0-007f-0132-8277-1eba7344906a",
-        "status": "error",
-        "commit_id": "fab58ad0ba4ec78efee303ef6d3dd9824cab2c78",
-        "message": "corrected backbone and less config issues.",
-        "branch": "master"
-      }, {
-        "id": 1000004,
-        "uuid": "8905dee0-e9d9-0131-1ab9-0ec2eab3611a",
-        "status": "success",
-        "commit_id": "84beb1684c33fdb7f7287ea634adcfbdb6a6d59b",
-        "message": "testing deployment via codeship through heroku",
-        "branch": "master"
-      }
-    ],
     "repository_name": "falafel/chickpea"
   },
 
   good2: {
-    "id": 8888,
-    "builds": [
-      {
-        "id": 2000001,
-        "uuid": "2f406670-007f-0132-cb2f-5247614ee66f",
-        "status": "success",
-        "commit_id": "03aa27da48bf5d6ee5c162351a2d7f721cc1ad28",
-        "message": "testing a codeship build",
-        "branch": "backbonify"
-      }
-    ],
-    "repository_name": "falafel/hummus"
+    "id": 9998,
+    "repository_name": "falafel/chickpea"
   },
-
-  bad: {
-    "id": 77777,
-    "builds": [ {
-        "id": 2000002,
-        "uuid": "d11930d0-e9ae-0131-0f9a-5e10f8b94a21",
-        "status": "error",
-        "commit_id": "c09f551dfa210b30a288ef1c71d22153ae0fbeac",
-        "message": "this is probably broken.",
-        "branch": "master"
-    }],
-    "repository_name": "falafel/isotope"
-  },
-
-  testing: {
-    "id": 66666,
-    "builds": [
-      {
-        "id": 3000001,
-        "uuid": "2f406670-007f-0132-cb2f-5247614ee66f",
-        "status": "testing",
-        "commit_id": "03aa27da48bf5d6ee5c162351a2d7f721cc1ad28",
-        "message": "testing a codeship build",
-        "branch": "master"
-      },
-      {
-        "id": 3000002,
-        "uuid": "2f406670-007f-0132-cb2f-5247614ee66f",
-        "status": "success",
-        "commit_id": "03aa27da48bf5d6ee5c162351a2d7f721cc1ad28",
-        "message": "this is a very long build message that should be ellipsified so it will fit",
-        "branch": "flummox"
-      }
-    ],
-    "repository_name": "falafel/tahini"
-  },
-  stopped: {
-    "id": 77777,
-    "builds": [
-      {
-        "id": 4000001,
-        "uuid": "2f406670-007f-0132-cb2f-5247614ee66f",
-        "status": "stopped",
-        "commit_id": "03aa27da48bf5d6ee5c162351a2d7f721cc1ad28",
-        "message": "testing a codeship build",
-        "branch": "master"
-      },
-    ]
-  }
 }

--- a/test/fixtures/project.js
+++ b/test/fixtures/project.js
@@ -1,11 +1,13 @@
 var ProjectFixtures = {
   good: {
     "id": 9999,
-    "repository_name": "falafel/chickpea"
+    "repository_name": "falafel/chickpea",
+    "builds": []
   },
 
   good2: {
     "id": 9998,
-    "repository_name": "falafel/chickpea"
+    "repository_name": "falafel/pickle",
+    "builds": []
   },
 }

--- a/test/unit/collections/projects_spec.js
+++ b/test/unit/collections/projects_spec.js
@@ -4,13 +4,13 @@ describe('Projects', function() {
 
   beforeEach(function() {
     var project1 = new Project(ProjectFixtures.good),
-        project2 = new Project(ProjectFixtures.good2)
-    projects = new Projects([project1, project2])
-    builds = new Builds(BuildFixtures.error)
+        project2 = new Project(ProjectFixtures.good2),
+        goodBuilds = new Builds(BuildFixtures.good),
+        badBuilds = new Builds(BuildFixtures.error)
 
-    projects.each(function(project) {
-      project.set({builds: builds})
-    })
+    project1.set({builds: goodBuilds})
+    project2.set({builds: badBuilds})
+    projects = new Projects([project1, project2])
   })
 
   it('should have loaded both projects correctly', function() {
@@ -29,10 +29,10 @@ describe('Projects', function() {
       status.should.eql({count: 2, state: Build.STATES.success})
     })
 
-    it('should summarize all projects, including testing build', function() {
-      projects = new Projects([ProjectFixtures.good, ProjectFixtures.testing])
+    it('should summarize all projects', function() {
+      // projects = new Projects([ProjectFixtures.good, ProjectFixtures.testing])
       var status = projects.getSummary()
-      status.should.eql({count: 1, state: Build.STATES.testing})
+      status.should.eql({count: 1, state: Build.STATES.error})
     })
   })
 })

--- a/test/unit/collections/projects_spec.js
+++ b/test/unit/collections/projects_spec.js
@@ -3,7 +3,9 @@ describe('Projects', function() {
   var projects, builds
 
   beforeEach(function() {
-    projects = new Projects([ProjectFixtures.good, ProjectFixtures.good2])
+    var project1 = new Project(ProjectFixtures.good),
+        project2 = new Project(ProjectFixtures.good2)
+    projects = new Projects([project1, project2])
     builds = new Builds(BuildFixtures.error)
 
     projects.each(function(project) {

--- a/test/unit/collections/projects_spec.js
+++ b/test/unit/collections/projects_spec.js
@@ -1,9 +1,14 @@
 describe('Projects', function() {
   'use strict'
-  var projects
+  var projects, builds
 
   beforeEach(function() {
-    projects = new Projects([ProjectFixtures.good, ProjectFixtures.bad])
+    projects = new Projects([ProjectFixtures.good, ProjectFixtures.good2])
+    builds = new Builds(BuildFixtures.error)
+
+    projects.each(function(project) {
+      project.set({builds: builds})
+    })
   })
 
   it('should have loaded both projects correctly', function() {

--- a/test/unit/collections/projects_spec.js
+++ b/test/unit/collections/projects_spec.js
@@ -30,7 +30,6 @@ describe('Projects', function() {
     })
 
     it('should summarize all projects', function() {
-      // projects = new Projects([ProjectFixtures.good, ProjectFixtures.testing])
       var status = projects.getSummary()
       status.should.eql({count: 1, state: Build.STATES.error})
     })

--- a/test/unit/models/project_spec.js
+++ b/test/unit/models/project_spec.js
@@ -24,7 +24,8 @@ describe('Project', function() {
     })
 
     it('should summarize a bad build', function() {
-      project = new Project(ProjectFixtures.bad)
+      project = new Project(ProjectFixtures.good)
+      project.set({builds: new Builds(BuildFixtures.error)})
       var status = project.getStatus()
       status.should.have.property('status', Build.STATES.error)
     })

--- a/test/unit/util/build_watcher_spec.js
+++ b/test/unit/util/build_watcher_spec.js
@@ -1,6 +1,6 @@
 describe('BuildWatcher', function() {
   'use strict'
-  var watcher, projects
+  var watcher, projects, buildsCollection, projectsCollection
 
   before(function() {
     chrome = {
@@ -17,22 +17,40 @@ describe('BuildWatcher', function() {
   })
 
   it('ignores any builds that are not testing', function() {
-    projects = [ProjectFixtures.good, ProjectFixtures.good2]
-    watcher.scan(projects)
+    buildsCollection = new Builds(BuildFixtures.good)
+    projectsCollection = new Projects([ProjectFixtures.good, ProjectFixtures.good2])
+
+    projectsCollection.each(function(project) {
+      project.set({builds: buildsCollection})
+    })
+
+    watcher.scan(projectsCollection)
     watcher.getWatchList().should.eql({})
   })
 
   it('remembers builds that are testing', function() {
-    projects = [ProjectFixtures.good, ProjectFixtures.testing]
-    watcher.scan(projects)
-    watcher.getWatchList().should.eql({"2f406670-007f-0132-cb2f-5247614ee66f": ProjectFixtures.testing.builds[0]})
+    buildsCollection = new Builds(BuildFixtures.testing)
+    projectsCollection = new Projects([ProjectFixtures.good, ProjectFixtures.good2])
+
+    projectsCollection.each(function(project) {
+      project.set({builds: buildsCollection})
+    })
+
+    watcher.scan(projectsCollection)
+    watcher.getWatchList().should.eql({"2f406670-007f-0132-cb2f-5247614ee66f": BuildFixtures.testing[0]})
   })
 
   describe('notifications', function() {
     var alertOptions
 
     beforeEach(function() {
-      projects = [ProjectFixtures.good, ProjectFixtures.testing]
+      buildsCollection = new Builds(BuildFixtures.testing)
+      projectsCollection = new Projects([ProjectFixtures.good, ProjectFixtures.good2])
+
+      projectsCollection.each(function(project) {
+        project.set({builds: buildsCollection})
+      })
+
       alertOptions = {
         type: "basic",
         title: "shipscope",
@@ -40,7 +58,6 @@ describe('BuildWatcher', function() {
         priority: 1,
         iconUrl: "img/shipscope_icon48.png"
       }
-      projects[1].builds[0].status = 'testing'
 
       sinon.spy(chrome.notifications, 'create')
     })

--- a/test/unit/views/build_spec.js
+++ b/test/unit/views/build_spec.js
@@ -4,15 +4,8 @@ describe('Build View', function() {
   var build, view
 
   beforeEach(function() {
-    // var parent = document.createElement('div')
-    // parent.id = 'build_item'
-    // document.body.appendChild(parent)
-    // console.debug(document.body)
-    //
-
-    build = new Build(ProjectFixtures.good.builds[0])
+    build = new Build(BuildFixtures.good[0])
     view = new BuildView({model: build, projectId: 12345})
-    // view.render()
   })
 
   it('should set the projectId on the view when initializing', function() {
@@ -49,11 +42,4 @@ describe('Build View', function() {
       helper.getStatusIcon.bind(build.attributes)().should.equal('info')
     })
   })
-
-  // it('should render when the status of a build changes', function() {
-  //   sinon.stub(view, 'onStatusChange')
-  //   build.set({status: 'testing'})
-  //
-  //   view.onStatusChange.calledOnce.should.be.true
-  // })
 })

--- a/test/unit/views/builds_spec.js
+++ b/test/unit/views/builds_spec.js
@@ -6,7 +6,8 @@ describe('Build View', function() {
 
   beforeEach(function() {
     project = new Project(ProjectFixtures.good)
-    builds = new Builds(project.attributes.builds)
+    builds = new Builds(BuildFixtures.good)
+    project.set({builds: builds})
     view = new BuildsView({collection: builds}, {projectId: project.id})
   })
 
@@ -25,7 +26,7 @@ describe('Build View', function() {
         type: 'click',
         currentTarget: {
           dataset: {
-            id: project.attributes.builds[0].id
+            id: project.attributes.builds.at(0).id
           }
         },
         preventDefault: function() {}

--- a/test/unit/views/project_spec.js
+++ b/test/unit/views/project_spec.js
@@ -5,6 +5,7 @@ describe('Project View', function() {
   var project, view
   beforeEach(function() {
     project = new Project(ProjectFixtures.good)
+    project.set({builds: new Builds(BuildFixtures.good)})
     view = new ProjectView({model: project})
   })
 
@@ -15,8 +16,9 @@ describe('Project View', function() {
 
       status.should.equal('success')
     })
+
     it('should provide the project status for a successful build', function() {
-      project.attributes.builds[0].status = 'stopped'
+      project.attributes.builds.at(0).attributes.status = 'stopped'
       var p = view.serializeData()
       var status = view.templateHelpers.getStatus.bind(p)()
 
@@ -24,8 +26,8 @@ describe('Project View', function() {
     })
 
     it('should provide the project status for a successful build', function() {
-      project.attributes.builds[0].status = 'error'
-      project.attributes.builds[0].branch = 'master'
+      project.attributes.builds.at(0).attributes.status = 'error'
+      project.attributes.builds.at(0).attributes.branch = 'master'
       var p = view.serializeData()
       var status = view.templateHelpers.getStatus.bind(p)()
 
@@ -33,8 +35,8 @@ describe('Project View', function() {
     })
 
     it('should provide the project status for a successful build', function() {
-      project.attributes.builds[0].status = 'testing'
-      project.attributes.builds[0].branch = 'master'
+      project.attributes.builds.at(0).attributes.status = 'testing'
+      project.attributes.builds.at(0).attributes.branch = 'master'
       var p = view.serializeData()
       var status = view.templateHelpers.getStatus.bind(p)()
 

--- a/test/unit/views/project_spec.js
+++ b/test/unit/views/project_spec.js
@@ -26,8 +26,8 @@ describe('Project View', function() {
     })
 
     it('should provide the project status for a successful build', function() {
-      project.attributes.builds.at(0).attributes.status = 'error'
-      project.attributes.builds.at(0).attributes.branch = 'master'
+      project.get('builds').at(0).set({status: 'error'})
+      project.get('builds').at(0).set({branch: 'master'})
       var p = view.serializeData()
       var status = view.templateHelpers.getStatus.bind(p)()
 

--- a/test/unit/views/projects_spec.js
+++ b/test/unit/views/projects_spec.js
@@ -6,6 +6,7 @@ var App = {
     }
   }
 }
+
 describe('Projects View', function() {
   'use strict'
 


### PR DESCRIPTION
Reduce load on mothership by breaking up api requests. Rather than using one request to fetch projects and builds together, fetch all projects first, then make separate requests for the builds for each project.

This will also help with issue #4